### PR TITLE
Make query.first return a promise when no callback is specified

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - 0.8
+  - "0.8"
   - "0.10"
+  - "0.12"

--- a/index.js
+++ b/index.js
@@ -75,7 +75,13 @@ query.first = function(text, values, cb) {
   if(values && !util.isArray(values)) {
     values = [values]
   }
-  query(text, values, function(err, rows) {
-    return cb(err, rows ? rows[0] : null)
-  })
+  if(typeof cb === 'undefined') {
+    return query(text, values).spread(function(rows) {
+      return rows ? rows[0] : null;
+    });
+  } else {
+    return query(text, values, function(err, rows) {
+      cb(err, rows ? rows[0] : null)
+    });
+  }
 }

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ var nodefn = require('when/node');
 var util = require('util')
 
 var Query = function() {
-  this.name = null;
   this.text = null;
   this.values = null;
 }

--- a/test/first.js
+++ b/test/first.js
@@ -51,8 +51,7 @@ describe('query.first', function() {
     assert(when.isPromiseLike(promise));
     promise.then(function(res) {
       assert.equal(res.name, 'brian');
-      done();
-    }).otherwise(done);
+    }).ensure(done);
   })
 
   it('does not return a promise if callback is passed', function(done) {

--- a/test/first.js
+++ b/test/first.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 var ok = require('okay');
 var query = require('../');
+var when = require('when');
 var pg = require('pg');
 pg.defaults.poolSize = 1;
 
@@ -43,6 +44,23 @@ describe('query.first', function() {
       assert.equal(res.name, 'brian')
       done()
     }))
+  })
+
+  it('returns a promise if no callback is passed', function(done) {
+    var promise = query.first('SELECT name FROM something WHERE age = 30');
+    assert(when.isPromiseLike(promise));
+    promise.then(function(res) {
+      assert.equal(res.name, 'brian');
+      done();
+    }).otherwise(done);
+  })
+
+  it('does not return a promise if callback is passed', function(done) {
+    var noPromise = query.first('SELECT name FROM something WHERE age = 30', function(err, res) {
+      assert(!when.isPromiseLike(noPromise));
+      assert.equal(res.name, 'brian');
+      done();
+    });
   })
 
   //keep this test last. it blows the connection away on error

--- a/test/index.js
+++ b/test/index.js
@@ -133,8 +133,7 @@ describe('query', function() {
         assert(util.isArray(rows));
         assert.equal(result.rows.length, 1);
         assert.equal(rows, result.rows);
-        done();
-      }).otherwise(done);
+      }).ensure(done);
     });
 
     it('does not return a promise if callback is passed', function(done) {


### PR DESCRIPTION
I use pg-query mostly inside promise chains, and was a little surprised to learn that `query.first` does not return a promise when no callback is passed. So I've added that feature in. :sunglasses:
