### PR TITLE
Allowing for own connection params with backwards compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var Query = function() {
   this.values = null;
 }
 
-var query = module.exports = function(text, values, cb) {
+function innerQuery(connectionParameters, text, values, cb) {
   var q = new Query();
 
   //normalize params
@@ -45,7 +45,7 @@ var query = module.exports = function(text, values, cb) {
     cb = nodefn.createCallback(defer.resolver);
   }
 
-  (query.pg || pg).connect(query.connectionParameters, ok(cb, function(client, done) {
+  (query.pg || pg).connect(connectionParameters, ok(cb, function(client, done) {
     var onError = function(err) {
       done(err);
       cb(err);
@@ -63,9 +63,15 @@ var query = module.exports = function(text, values, cb) {
   return q;
 };
 
+var query = module.exports = function(text, values, cb) {
+    return innerQuery(query.connectionParameters, text, values, cb);
+};
+
 query.before = function(query, client) {
 
 };
+
+query.ownConnection = innerQuery;
 
 query.first = function(text, values, cb) {
   if(typeof values == 'function') {


### PR DESCRIPTION
When used as default in an app (such as an express web app), you're only able to have one connection at a time. We've got a use case which would benefit from the ease of calling just the query interface but to have multiple connections possible.

This allows for a non-breaking usage with 

``` javascript
query.connectionParameters = 'foo';
query.query('select * from bar');
```

But also extends the interface with 

``` javascript
query.ownConnection('foo','select * from bar')
```
