### PR TITLE
adding support for squel

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ var query = module.exports = function(text, values, cb) {
     q.values = values;
   } else if(typeof text === 'object') {
     //support toQuery and object style interface
-    q = text.toQuery ? text.toQuery() : text;
+    q = text.toQuery ? text.toQuery() : (text.toParam ? text.toParam() : text.toString());
   }
 
 


### PR DESCRIPTION
Squel allows users a programmatic way of generating SQL requests which I've been using in my personal projects. I've also been using pg-query, which is pretty neat!

One of the difficulties has been in trying to use pg-query and Squel together because pg-query just returns the object rather then checking to see if the function toParam exists, which Squel uses. I've tested this edit in a number of my projects and it works fine.

I also changed the text to return a toString rather than just the object so that if the users overwrites toString to include an implementation of a query, it will work rather than just returning an object.

Let me know what you think!